### PR TITLE
Fix AttributeError: '_SingleProcessDataLoaderIter' object has no attribute ' 

### DIFF
--- a/experiments/nyuv2/trainer.py
+++ b/experiments/nyuv2/trainer.py
@@ -164,7 +164,7 @@ def main(path, lr, bs, device):
         with torch.no_grad():  # operations inside don't track history
             test_dataset = iter(test_loader)
             for k in range(test_batch):
-                test_data, test_label, test_depth, test_normal = test_dataset.next()
+                test_data, test_label, test_depth, test_normal = next(test_dataset) #test_dataset.next()#.next is deprecated
                 test_data, test_label = test_data.to(device), test_label.long().to(
                     device
                 )


### PR DESCRIPTION
I followed the instructions on github this repo to run experiments and met this problem:

(nashmtl) [xxx@a nyuv2]$ python trainer.py --method=mgda --wandb_project=mdgalp_wandb_project --wandb_entity=mdgalp_wandb_entuty
2023-05-06 00:03:25,608 - root - INFO - Applying data augmentation on NYUv2.

[1  398/398] semantic loss: 1.581, depth loss: 1.269, normal loss: 0.303:   0Traceback (most recent call last):
  File "/xxx/nash-mtl-main/experiments/nyuv2/trainer.py", line 274, in <module>
    main(path=args.data_path, lr=args.lr, bs=args.batch_size, device=device)
  File "/xxx/nash-mtl-main/experiments/nyuv2/trainer.py", line 167, in main
    test_data, test_label, test_depth, test_normal = test_dataset.next()
AttributeError: '_SingleProcessDataLoaderIter' object has no attribute ' 


I changed the nash-mtl-main/experiments/nyuv2/trainer.py  Line 167.
 original "test_dataset.next()" is changed into "next(test_dataset)"

This might be due to a change in PyTorch version, since next() is deprecated and should be replaced with __next__(). A possible solution would be to replace test_dataset.next() with next(test_dataset) on line 167.